### PR TITLE
Add Centimeter and Millimeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ composer require prinsfrank/measurement-unit
 
 | Type        | Available unit                                                                                                |
 |-------------|---------------------------------------------------------------------------------------------------------------|
-| Length      | Fathom, Foot, Furlong, HorseLength, Inch, Meter, Kilometer, NauticalMile, StatuteMile, SurveyMile, Thou, Yard |
+| Length      | Centimeter, Fathom, Foot, Furlong, HorseLength, Inch, Kilometer, Meter, Millimeter, NauticalMile, StatuteMile, SurveyMile, Thou, Yard |
 | Speed       | KilometerPerHour, Knot, MeterPerSecond, MilesPerHour                                                          |
 | Temperature | Celsius, Fahrenheit, Kelvin, Rankine                                                                          |
 | Time        | Day, Hour, Minute, Second                                                                                     |

--- a/src/Length/Centimeter.php
+++ b/src/Length/Centimeter.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace PrinsFrank\MeasurementUnit\Length;
+
+use PrinsFrank\ArithmeticOperations\ArithmeticOperations;
+
+class Centimeter extends Length
+{
+    public static function getSymbol(): string
+    {
+        return 'cm';
+    }
+
+    public static function fromMeterValue(float $value, ArithmeticOperations $arithmeticOperations): self
+    {
+        return new self($arithmeticOperations->divide($value, 0.01), $arithmeticOperations);
+    }
+
+    public function toMeterValue(): float
+    {
+        return $this->arithmeticOperations->multiply($this->value, 0.01);
+    }
+}

--- a/src/Length/Length.php
+++ b/src/Length/Length.php
@@ -15,6 +15,11 @@ abstract class Length implements LengthInterface
         $this->arithmeticOperations = $arithmeticOperations ?? new ArithmeticOperationsFloatingPoint();
     }
 
+    public function toCentimeter(): Centimeter
+    {
+        return $this->toUnit(Centimeter::class);
+    }
+
     public function toFathom(): Fathom
     {
         return $this->toUnit(Fathom::class);
@@ -48,6 +53,11 @@ abstract class Length implements LengthInterface
     public function toMeter(): Meter
     {
         return $this->toUnit(Meter::class);
+    }
+
+    public function toMillimeter(): Millimeter
+    {
+        return $this->toUnit(Millimeter::class);
     }
 
     public function toStatuteMile(): StatuteMile

--- a/src/Length/Millimeter.php
+++ b/src/Length/Millimeter.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace PrinsFrank\MeasurementUnit\Length;
+
+use PrinsFrank\ArithmeticOperations\ArithmeticOperations;
+
+class Millimeter extends Length
+{
+    public static function getSymbol(): string
+    {
+        return 'mm';
+    }
+
+    public static function fromMeterValue(float $value, ArithmeticOperations $arithmeticOperations): self
+    {
+        return new self($arithmeticOperations->divide($value, 0.001), $arithmeticOperations);
+    }
+
+    public function toMeterValue(): float
+    {
+        return $this->arithmeticOperations->multiply($this->value, 0.001);
+    }
+}

--- a/tests/Integration/LengthTest.php
+++ b/tests/Integration/LengthTest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 namespace PrinsFrank\MeasurementUnit\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
+use PrinsFrank\MeasurementUnit\Length\Centimeter;
 use PrinsFrank\MeasurementUnit\Length\Fathom;
 use PrinsFrank\MeasurementUnit\Length\Foot;
 use PrinsFrank\MeasurementUnit\Length\Furlong;
 use PrinsFrank\MeasurementUnit\Length\HorseLength;
 use PrinsFrank\MeasurementUnit\Length\Inch;
+use PrinsFrank\MeasurementUnit\Length\Kilometer;
 use PrinsFrank\MeasurementUnit\Length\Length;
 use PrinsFrank\MeasurementUnit\Length\Meter;
+use PrinsFrank\MeasurementUnit\Length\Millimeter;
 use PrinsFrank\MeasurementUnit\Length\StatuteMile;
 use PrinsFrank\MeasurementUnit\Length\NauticalMile;
 use PrinsFrank\MeasurementUnit\Length\SurveyMile;
@@ -22,12 +25,15 @@ class LengthTest extends TestCase
 {
     /** @var array<class-string<Length>> */
     private const LENGTH_FQN_S = [
+        Centimeter::class,
         Fathom::class,
         Foot::class,
         Furlong::class,
         HorseLength::class,
         Inch::class,
+        Kilometer::class,
         Meter::class,
+        Millimeter::class,
         StatuteMile::class,
         NauticalMile::class,
         SurveyMile::class,
@@ -51,11 +57,14 @@ class LengthTest extends TestCase
 
     public function testCorrectConversionRate(): void
     {
+        static::assertEqualsWithDelta(new Meter(0.42), (new Centimeter(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(76.8096), (new Fathom(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(12.8016), (new Foot(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(8449.056), (new Furlong(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(100.8), (new HorseLength(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(1.0668), (new Inch(42.0))->toMeter(), 0.000001);
+        static::assertEqualsWithDelta(new Meter(42000.0), (new Kilometer(42.0))->toMeter(), 0.000001);
+        static::assertEqualsWithDelta(new Meter(0.042), (new Millimeter(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(42.0), (new Meter(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(67592.448), (new StatuteMile(42.0))->toMeter(), 0.000001);
         static::assertEqualsWithDelta(new Meter(77784), (new NauticalMile(42.0))->toMeter(), 0.000001);

--- a/tests/Unit/Length/CentimeterTest.php
+++ b/tests/Unit/Length/CentimeterTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace PrinsFrank\MeasurementUnit\Tests\Unit\Length;
+
+use PHPUnit\Framework\TestCase;
+use PrinsFrank\ArithmeticOperations\ArithmeticOperations;
+use PrinsFrank\MeasurementUnit\Length\Centimeter;
+
+/**
+ * @coversDefaultClass \PrinsFrank\MeasurementUnit\Length\Centimeter
+ */
+class CentimeterTest extends TestCase
+{
+    /**
+     * @covers ::getSymbol
+     */
+    public function testGetSymbol(): void
+    {
+        static::assertSame('cm', Centimeter::getSymbol());
+    }
+
+    /**
+     * @covers ::fromMeterValue
+     */
+    public function testFromMeterValue(): void
+    {
+        $arithmeticOperations = $this->createMock(ArithmeticOperations::class);
+        $arithmeticOperations->expects(self::once())
+            ->method('divide')
+            ->with(42.0, 0.01)
+            ->willReturn(4200.0);
+
+        static::assertEquals(
+            new Centimeter(4200.0, $arithmeticOperations),
+            Centimeter::fromMeterValue(42.0, $arithmeticOperations)
+        );
+    }
+
+    /**
+     * @covers ::toMeterValue
+     */
+    public function testToMeterValue(): void
+    {
+        $arithmeticOperations = $this->createMock(ArithmeticOperations::class);
+        $arithmeticOperations->expects(self::once())
+            ->method('multiply')
+            ->with(42.0, 0.01)
+            ->willReturn(0.42);
+
+        static::assertSame(0.42, (new Centimeter(42.0, $arithmeticOperations))->toMeterValue());
+    }
+}

--- a/tests/Unit/Length/MillimeterTest.php
+++ b/tests/Unit/Length/MillimeterTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace PrinsFrank\MeasurementUnit\Tests\Unit\Length;
+
+use PHPUnit\Framework\TestCase;
+use PrinsFrank\ArithmeticOperations\ArithmeticOperations;
+use PrinsFrank\MeasurementUnit\Length\Millimeter;
+
+/**
+ * @coversDefaultClass \PrinsFrank\MeasurementUnit\Length\Millimeter
+ */
+class MillimeterTest extends TestCase
+{
+    /**
+     * @covers ::getSymbol
+     */
+    public function testGetSymbol(): void
+    {
+        static::assertSame('mm', Millimeter::getSymbol());
+    }
+
+    /**
+     * @covers ::fromMeterValue
+     */
+    public function testFromMeterValue(): void
+    {
+        $arithmeticOperations = $this->createMock(ArithmeticOperations::class);
+        $arithmeticOperations->expects(self::once())
+            ->method('divide')
+            ->with(42.0, 0.001)
+            ->willReturn(42000.0);
+
+        static::assertEquals(
+            new Millimeter(42000.0, $arithmeticOperations),
+            Millimeter::fromMeterValue(42.0, $arithmeticOperations)
+        );
+    }
+
+    /**
+     * @covers ::toMeterValue
+     */
+    public function testToMeterValue(): void
+    {
+        $arithmeticOperations = $this->createMock(ArithmeticOperations::class);
+        $arithmeticOperations->expects(self::once())
+            ->method('multiply')
+            ->with(42.0, 0.001)
+            ->willReturn(0.042);
+
+        static::assertSame(0.042, (new Millimeter(42.0, $arithmeticOperations))->toMeterValue());
+    }
+}


### PR DESCRIPTION
Also adds missing Kilometer to the Integration test.

Conforms to the library's architecture and patterns.

- Readme updated
- All Unit and Integration tests provided and passing.
- PHP-cs-fix and PHPStan are also satisfied.

Closes issues #18 and #19 